### PR TITLE
fix: include root reporter files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "index.js",
     "index.cjs",
     "global.js",
+    "reporters.js",
+    "reporters.cjs",
     "testGlobal.js",
     "README.md"
   ],


### PR DESCRIPTION
## Fix

* Include root reporter files in `package.json#files` section so the are included in the npm pacakge

