### PR TITLE
feat: test run callbacks

### DIFF
--- a/src/test/__tests__/callbacks.ts
+++ b/src/test/__tests__/callbacks.ts
@@ -1,0 +1,387 @@
+import { ParkinTest } from '../test'
+import {
+  EResultType,
+  EResultAction,
+  EResultStatus,
+} from '../../types'
+
+describe(`ParkinTest.run`, () => {
+
+  it(`should always call the spec start and done callbacks when passed`, async () => {
+    const onSpecStart = jest.fn()
+    const onSpecDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn(() => {
+      throw new Error(`Failed Test`)
+    })
+    const test3 = jest.fn()
+
+    const PTE = new ParkinTest({
+      onSpecDone,
+      onSpecStart,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+      PTE.test(`test-2`, test2)
+      
+      PTE.describe(`describe-1-1`, () => {
+        PTE.test(`test-1-1-1`, test3)
+      })
+    })
+
+    await PTE.run()
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).toHaveBeenCalledTimes(1)
+    expect(test3).toHaveBeenCalledTimes(1)
+    expect(onSpecStart).toHaveBeenCalledTimes(3)
+    expect(onSpecDone).toHaveBeenCalledTimes(3)
+    
+    onSpecStart.mock.calls.forEach((call:any) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.test)
+      expect(result.action).toBe(EResultAction.start)
+      expect(result.failed).toBe(false)
+      expect(result.passed).toBe(false)
+    })
+
+    onSpecDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.test)
+      expect(result.action).toBe(EResultAction.end)
+
+      if(idx === 1){
+        expect(result.failed).toBe(true)
+        expect(result.passed).toBe(false)
+        expect(result.status).toBe(EResultStatus.failed)
+      }
+      else {
+        expect(result.passed).toBe(true)
+        expect(result.failed).toBe(false)
+        expect(result.status).toBe(EResultStatus.passed)
+      }
+    })
+
+  })
+
+  it(`should always call the suit start and done callbacks when passed`, async () => {
+    const onSuiteStart = jest.fn()
+    const onSuiteDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn(() => {
+      throw new Error(`Failed Test`)
+    })
+    const test3 = jest.fn()
+
+    const PTE = new ParkinTest({
+      onSuiteDone,
+      onSuiteStart,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+      PTE.test(`test-2`, test2)
+      
+      PTE.describe(`describe-1-1`, () => {
+        PTE.test(`test-1-1-1`, test3)
+      })
+    })
+
+    await PTE.run()
+
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).toHaveBeenCalledTimes(1)
+    expect(test3).toHaveBeenCalledTimes(1)
+    expect(onSuiteStart).toHaveBeenCalledTimes(2)
+    expect(onSuiteDone).toHaveBeenCalledTimes(2)
+
+    onSuiteStart.mock.calls.forEach((call:any) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.describe)
+      expect(result.action).toBe(EResultAction.start)
+      expect(result.failed).toBe(false)
+      expect(result.passed).toBe(false)
+    })
+
+    onSuiteDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.describe)
+      expect(result.action).toBe(EResultAction.end)
+
+      if(idx === 1){
+        expect(result.failed).toBe(true)
+        expect(result.passed).toBe(false)
+        expect(result.status).toBe(EResultStatus.failed)
+      }
+      else {
+        expect(result.passed).toBe(true)
+        expect(result.failed).toBe(false)
+        expect(result.status).toBe(EResultStatus.passed)
+      }
+    })
+
+  })
+
+  it(`should always call the run start and done callbacks when passed`, async () => {
+    const onRunStart = jest.fn()
+    const onRunDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn(() => {
+      throw new Error(`Failed Test`)
+    })
+    const test3 = jest.fn()
+
+    const PTE = new ParkinTest({
+      onRunStart,
+      onRunDone,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+      PTE.test(`test-2`, test2)
+      
+      PTE.describe(`describe-1-1`, () => {
+        PTE.test(`test-1-1-1`, test3)
+      })
+    })
+
+    await PTE.run()
+
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).toHaveBeenCalledTimes(1)
+    expect(test3).toHaveBeenCalledTimes(1)
+    expect(onRunStart).toHaveBeenCalledTimes(1)
+    expect(onRunDone).toHaveBeenCalledTimes(1)
+
+    onRunStart.mock.calls.forEach((call:any) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.root)
+      expect(result.action).toBe(EResultAction.start)
+      expect(result.failed).toBe(false)
+      expect(result.passed).toBe(false)
+    })
+
+    onRunDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.root)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+  })
+
+  it(`should always call all callbacks when not errors are thrown`, async () => {
+    const onSpecStart = jest.fn()
+    const onSpecDone = jest.fn()
+    const onSuiteStart = jest.fn()
+    const onSuiteDone = jest.fn()
+    const onRunStart = jest.fn()
+    const onRunDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn()
+    const test3 = jest.fn()
+
+    const PTE = new ParkinTest({
+      onSpecStart,
+      onSpecDone,
+      onSuiteStart,
+      onSuiteDone,
+      onRunStart,
+      onRunDone,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+      PTE.test(`test-2`, test2)
+
+      PTE.describe(`describe-1-1`, () => {
+        PTE.test(`test-1-1-1`, test3)
+      })
+    })
+
+    await PTE.run()
+
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).toHaveBeenCalledTimes(1)
+    expect(test3).toHaveBeenCalledTimes(1)
+    expect(onSuiteStart).toHaveBeenCalledTimes(2)
+    expect(onSuiteDone).toHaveBeenCalledTimes(2)
+    expect(onRunStart).toHaveBeenCalledTimes(1)
+    expect(onRunDone).toHaveBeenCalledTimes(1)
+    expect(onSpecStart).toHaveBeenCalledTimes(3)
+    expect(onSpecDone).toHaveBeenCalledTimes(3)
+
+  })
+
+  it(`should still call the suite and root callbacks if a spec callback throws`, async () => {
+    const onSpecDone = () => {
+      throw new Error(`On Spec Done Error`)
+    }
+    const onSuiteStart = jest.fn()
+    const onSuiteDone = jest.fn()
+    const onRunDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn(() => {
+      throw new Error(`Failed Test`)
+    })
+    const test3 = jest.fn()
+
+    const PTE = new ParkinTest({
+      onSpecDone,
+      onSuiteDone,
+      onSuiteStart,
+      onRunDone,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+      
+      PTE.test(`test-2`, test2)
+      
+      PTE.describe(`describe-1-1`, () => {
+        PTE.test(`test-1-1-1`, test3)
+      })
+    })
+
+    await PTE.run()
+
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).not.toHaveBeenCalledTimes(1)
+    expect(test3).not.toHaveBeenCalledTimes(1)
+    expect(onSuiteDone).toHaveBeenCalledTimes(1)
+    expect(onRunDone).toHaveBeenCalledTimes(1)
+
+    onSuiteDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.describe)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+    onRunDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.root)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+  })
+
+  it(`should still call the suite and root callbacks if a before hook callback throws`, async () => {
+
+    const onSuiteDone = jest.fn()
+    const onRunDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn()
+    const beforeEach = jest.fn(() => {
+      throw new Error(`Failed beforeEach method`)
+    })
+
+    const PTE = new ParkinTest({
+      onSuiteDone,
+      onRunDone,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+
+      PTE.describe(`describe-1-1`, () => {
+        
+        PTE.beforeEach(beforeEach)
+        
+        PTE.test(`test-1-1-1`, test2)
+      })
+    })
+
+    await PTE.run()
+
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).not.toHaveBeenCalled()
+    expect(beforeEach).toHaveBeenCalledTimes(1)
+    expect(onSuiteDone).toHaveBeenCalledTimes(2)
+    expect(onRunDone).toHaveBeenCalledTimes(1)
+
+    onSuiteDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.describe)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+    onRunDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.root)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+  })
+
+  it(`should still call the suite and root callbacks if a after hook callback throws`, async () => {
+
+    const onSuiteDone = jest.fn()
+    const onRunDone = jest.fn()
+    const test1 = jest.fn()
+    const test2 = jest.fn()
+    const test3 = jest.fn()
+    const afterEach = jest.fn(() => {
+      throw new Error(`Failed afterEach method`)
+    })
+
+    const PTE = new ParkinTest({
+      onSuiteDone,
+      onRunDone,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1`, test1)
+
+      PTE.describe(`describe-1-1`, () => {
+        
+        PTE.afterEach(afterEach)
+        
+        PTE.test(`test-1-1-1`, test2)
+        PTE.test(`test-1-1-2`, test3)
+      })
+    })
+
+    await PTE.run()
+
+    expect(test1).toHaveBeenCalledTimes(1)
+    expect(test2).toHaveBeenCalledTimes(1)
+    expect(test3).not.toHaveBeenCalled()
+    expect(afterEach).toHaveBeenCalledTimes(1)
+    expect(onSuiteDone).toHaveBeenCalledTimes(2)
+    expect(onRunDone).toHaveBeenCalledTimes(1)
+
+    onSuiteDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.describe)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+    onRunDone.mock.calls.forEach((call:any, idx:number) => {
+      const result = call[0]
+      expect(result.type).toBe(EResultType.root)
+      expect(result.action).toBe(EResultAction.end)
+      expect(result.failed).toBe(true)
+      expect(result.passed).toBe(false)
+      expect(result.status).toBe(EResultStatus.failed)
+    })
+
+  })
+
+})

--- a/src/test/__tests__/run.ts
+++ b/src/test/__tests__/run.ts
@@ -140,10 +140,10 @@ describe(`ParkinTest.run`, () => {
   it(`should call the test callback hooks`, async () => {
     const config = {
       timeout: 8543,
-      specDone: jest.fn(),
-      suiteDone: jest.fn(),
-      specStarted: jest.fn(),
-      suiteStarted: jest.fn(),
+      onSpecDone: jest.fn(),
+      onSuiteDone: jest.fn(),
+      onSpecStart: jest.fn(),
+      onSuiteStart: jest.fn(),
     }
     const PTE = new ParkinTest(config)
 
@@ -159,10 +159,10 @@ describe(`ParkinTest.run`, () => {
     })
 
     await PTE.run()
-    expect(config.suiteStarted).toHaveBeenCalledTimes(2)
-    expect(config.suiteDone).toHaveBeenCalledTimes(2)
-    expect(config.specStarted).toHaveBeenCalledTimes(3)
-    expect(config.specDone).toHaveBeenCalledTimes(3)
+    expect(config.onSuiteStart).toHaveBeenCalledTimes(2)
+    expect(config.onSuiteDone).toHaveBeenCalledTimes(2)
+    expect(config.onSpecStart).toHaveBeenCalledTimes(3)
+    expect(config.onSpecDone).toHaveBeenCalledTimes(3)
   })
 
   it(`should only run tests in a describe.only block when set`, async () => {

--- a/src/test/__tests__/test.ts
+++ b/src/test/__tests__/test.ts
@@ -36,10 +36,10 @@ describe(`ParkinTest`, () => {
       expect(() => {
         const PTE = new ParkinTest({
           timeout: 8543,
-          specDone: jest.fn(),
-          suiteDone: jest.fn(),
-          specStarted: jest.fn(),
-          suiteStarted: jest.fn(),
+          onSpecDone: jest.fn(),
+          onSuiteDone: jest.fn(),
+          onSpecStart: jest.fn(),
+          onSuiteStart: jest.fn(),
           description: `Test Description`,
         })
         expect(PTE.timeout).toBe(8543)

--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -27,7 +27,7 @@ export type TDescribeHooks = {
   describe:TDescribeTestObj
   describeResult:TRunResult
   root:TDescribeTestObj | TRootTestObj
-  suiteDone:(result: TRunResult) => void
+  onSuiteDone:(result: TRunResult) => void
 }
 
 /**
@@ -146,26 +146,24 @@ export const callDescribeHooks = async (args:TDescribeHooks) => {
     type,
     suiteId,
     describe,
-    suiteDone,
+    onSuiteDone,
     describeResult
   } = args
 
   const results:TRunResult[] = []
 
-  const beforeResults = type === `before`
+  const hooksResults = type === `before`
     ? await callBeforeHooks({root, suiteId, describe })
     : await callAfterHooks({root, suiteId, describe })
   
-  if(!beforeResults?.length) return results
+  if(!hooksResults?.length) return results
   
-  if (beforeResults?.length) {
-    const describeResults = beforeResults.map(result => ({ ...describeResult, ...result }))
+  if (hooksResults?.length) {
+    const describeResults = hooksResults.map(result => {
+      const joined = {...describeResult, ...result, failed: true, passed: false }
+      onSuiteDone(joined)
 
-    suiteDone({
-      ...describeResult,
-      failed: true,
-      passed: false,
-      describes: describeResults,
+      return joined
     })
 
     results.push(...describeResults)

--- a/src/test/loopDescribes.ts
+++ b/src/test/loopDescribes.ts
@@ -1,0 +1,205 @@
+import type { TDescribeTestObj, TParkinTestCB, TRun, TRunResult, TRunResults } from '../types'
+
+import { runResult } from './runResult'
+import { loopTests } from './loopTests'
+import { callDescribeHooks } from './hooks'
+import { shouldSkipDescribe } from './runHelpers'
+import { EResultStatus, EResultAction } from '../types'
+
+
+export type TLoopChildren<T=any> = {
+  describeResult:TRunResult
+  onSuiteDone:TParkinTestCB
+  describe:TDescribeTestObj
+  loopFun:() => Promise<{tests?: TRunResults, describes?: TRunResults, failed: boolean }>
+}
+
+/**
+ * Helper method to loop over children of a describe test object
+ */
+const loopChildren = async (args:TLoopChildren) => {
+  const {
+    describe,
+    onSuiteDone,
+    describeResult,
+    loopFun,
+  } = args
+
+  try {
+    const results = await loopFun()
+    const failed = results?.failed || describeResult?.failed
+
+    const joined = {
+      ...describeResult,
+      ...results,
+      action: EResultAction.end,
+    }
+    if(failed) joined.failed = failed
+
+    return joined
+  }
+  /**
+    * If an error is thrown by something other then a test of hook then it will show up here
+    * We capture it so we can still call the onSuiteEnd callback, then rethrow the error
+    */
+  catch(err){
+    const errorResult = runResult(describe, {
+      ...describeResult,
+      action: EResultAction.end,
+      failed: {
+        error: err,
+        description: err.message,
+        status: EResultStatus.failed,
+        fullName: describe.description,
+      }
+    })
+    
+    onSuiteDone(errorResult)
+    if(!err.result) err.result = errorResult
+
+    throw err
+  }
+
+}
+
+/**
+ * Helper to loop over describe methods and call child tests
+ * @param {Object} args - Config to overwrite the initial test config object
+ *
+ * @returns {Object} - Built run results of the test results
+ */
+export const loopDescribes = async (args:TRun) => {
+  const {
+    root,
+    testOnly,
+    onSpecDone,
+    onSuiteDone,
+    testRetry,
+    shouldAbort,
+    onTestRetry,
+    onSpecStart,
+    onSuiteStart,
+    describeOnly,
+    parentIdx = ``,
+  } = args
+
+  let describeFailed = false
+  const results:TRunResults = []
+
+
+  // ------ loop describes ------ //
+  for (let idx = 0; idx < root.describes.length; idx++) {
+
+    if(shouldAbort()) break
+
+    const describe = root.describes[idx]
+    const suiteId = `suite-${parentIdx}${idx}`
+
+    // Create a runResult with general information that can be reused below
+    let describeResult = runResult(describe, {
+      id: suiteId,
+      testPath: `/${suiteId}`,
+      action: EResultAction.start,
+      fullName: describe.description,
+    })
+
+
+    if (shouldSkipDescribe({ describe, describeOnly, testOnly })) {
+      onSuiteStart({
+        ...describeResult,
+        skipped: true,
+        action: EResultAction.skipped,
+        status: EResultStatus.skipped,
+      })
+      continue
+    }
+    else onSuiteStart(describeResult)
+
+    const beforeResults = await callDescribeHooks({
+      root,
+      suiteId,
+      describe,
+      onSuiteDone,
+      describeResult,
+      type: `before`,
+    })
+
+    if (beforeResults?.length) {
+      describeFailed = true
+      results.push(...beforeResults)
+      continue
+    }
+
+    if(shouldAbort()) break
+
+    // Loop over any test children
+    describeResult = describe?.tests?.length
+      ? await loopChildren({
+          describe,
+          onSuiteDone,
+          describeResult,
+          loopFun: async () => await loopTests({
+            suiteId,
+            describe,
+            testOnly,
+            onSpecDone,
+            testRetry,
+            onTestRetry,
+            shouldAbort,
+            onSpecStart,
+          })
+        })
+      : describeResult
+
+    // Loop over any describe children
+    describeResult = describe?.describes?.length
+      ? await loopChildren({
+          describe,
+          onSuiteDone,
+          describeResult,
+          loopFun: async () => await loopDescribes({
+            ...args,
+            root: describe,
+            parentIdx: `${idx}-`,
+          })
+        })
+      : describeResult
+
+    if(shouldAbort()) break
+
+    if (describeResult.failed) {
+      describeFailed = true
+      describeResult.failed = true
+      describeResult.status = EResultStatus.failed
+    }
+    else {
+      describeResult.passed = true
+      describeResult.status = EResultStatus.passed
+    }
+
+    const afterResults = await callDescribeHooks({
+      root,
+      suiteId,
+      describe,
+      onSuiteDone,
+      describeResult,
+      type: `after`,
+    })
+
+    if (afterResults?.length) {
+      describeFailed = true
+      results.push(...afterResults)
+      continue
+    }
+
+    if(shouldAbort()) break
+
+    onSuiteDone(describeResult)
+    results.push(describeResult)
+  }
+
+  return shouldAbort()
+    ? { describes: [], failed: describeFailed }
+    : { describes: results, failed: describeFailed }
+
+}

--- a/src/test/loopTests.ts
+++ b/src/test/loopTests.ts
@@ -1,0 +1,150 @@
+import type { TLoopTests, TRunResult, TRunResults } from '../types'
+
+import { Types } from './utils'
+import { runTest } from './runTest'
+import { loopHooks } from './hooks'
+import { runResult } from './runResult'
+import { EResultStatus, EResultAction } from '../types'
+
+import {
+  buildTestArgs,
+  shouldSkipTest,
+} from './runHelpers'
+
+
+/**
+ * Helper to loop over tests and call their test method
+ *
+ * @returns {Object} - Built run result object of the test results
+ */
+export const loopTests = async (args:TLoopTests) => {
+  const {
+    suiteId,
+    describe,
+    testOnly,
+    onSpecDone,
+    testRetry,
+    onTestRetry,
+    shouldAbort,
+    onSpecStart
+  } = args
+
+  let testsFailed = false
+  const results:TRunResults = []
+
+  // ------ describe - loop tests ------ //
+  for (let testIdx = 0; testIdx < describe.tests.length; testIdx++) {
+
+    if(shouldAbort()) break
+
+    const {
+      test,
+      specId,
+      testPath,
+      fullName,
+    } = buildTestArgs({ suiteId, testIdx, describe })
+
+    let testResult = runResult(test, {
+      fullName,
+      testPath,
+      id: specId,
+      action: EResultAction.start,
+    })
+
+    if(shouldSkipTest({ testOnly, test })){
+      onSpecStart({
+        ...testResult,
+        skipped: true,
+        action: EResultAction.skipped,
+        status: EResultStatus.skipped,
+      })
+      continue
+    }
+    else onSpecStart(testResult)
+
+    if(shouldAbort()) break
+
+    const beforeEachResults = await loopHooks({
+      test,
+      specId,
+      suiteId,
+      describe,
+      type: Types.beforeEach,
+    })
+
+    if (beforeEachResults?.length) {
+      testsFailed = true
+      results.push(...beforeEachResults)
+      beforeEachResults.forEach(onSpecDone)
+      break
+    }
+
+    // ------ execute test ------ //
+    try {
+
+      /**
+       * If there is a timeout, Use the PromiseTimeout to race it against the test action
+       * If the timeout wins, it will reject the promise
+       * Which then gets picked up in the catch below
+       */
+      const result = await runTest({
+        test,
+        retry: testRetry,
+        onRetry: onTestRetry,
+      })
+
+      testResult = runResult(test, {
+        fullName,
+        id: specId,
+        testPath: testPath,
+        passed: result || true,
+        action: EResultAction.test,
+      })
+    }
+    catch (error) {
+      testResult = runResult(test, {
+        fullName,
+        id: specId,
+        testPath: testPath,
+        action: EResultAction.test,
+        failed: {
+          error,
+          fullName,
+          description: error.message,
+          status: EResultStatus.failed,
+        },
+      })
+
+      testsFailed = true
+    }
+    
+    if(shouldAbort()) break
+
+    const afterEachResults = await loopHooks({
+      test,
+      specId,
+      suiteId,
+      describe,
+      type: Types.afterEach,
+    })
+    if (afterEachResults?.length) {
+      testsFailed = true
+      results.push(...afterEachResults)
+      afterEachResults.forEach(onSpecDone)
+      break
+    }
+
+    results.push(testResult)
+
+    onSpecDone({
+      ...testResult,
+      action: EResultAction.end
+    })
+
+  }
+
+  return shouldAbort()
+    ? { tests: [], failed: testsFailed }
+    : { tests: results, failed: testsFailed }
+
+}

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -48,10 +48,12 @@ export class ParkinTest {
   #root = createRoot()
   xit:TTestSkipFactory
   it:TParkinTestFactory
-  #specDone:TParkinTestCB = noOp
-  #suiteDone:TParkinTestCB = noOp
-  #specStarted:TParkinTestCB = noOp
-  #suiteStarted:TParkinTestCB = noOp
+  #onRunDone:TParkinTestCB = noOp
+  #onRunStart:TParkinTestCB = noOp
+  #onSpecDone:TParkinTestCB = noOp
+  #onSuiteDone:TParkinTestCB = noOp
+  #onSpecStart:TParkinTestCB = noOp
+  #onSuiteStart:TParkinTestCB = noOp
   #onAbort:TParkinTestAbort = noOp
   afterAll:TTestHookMethod = noOp
   afterEach:TTestHookMethod = noOp
@@ -68,27 +70,29 @@ export class ParkinTest {
     this.it = this.test
     this.xit = this.xtest
     this.#activeParent = this.#root
-    this.#setConfig(config)
+    this.setConfig(config)
   }
 
   run = (config:TParkinTestConfig = noOpObj) => {
 
     if (config.description) this.#root.description = config.description
 
-    this.#setConfig(config)
+    this.setConfig(config)
     const runSuite = async () => {
       const promise = run({
         root: this.#root,
         onAbort: this.#onAbort,
         testOnly: this.#testOnly,
-        specDone: this.#specDone,
+        onSpecDone: this.#onSpecDone,
         testRetry: this.testRetry,
-        suiteDone: this.#suiteDone,
-        specStarted: this.#specStarted,
+        onRunDone: this.#onRunDone,
+        onSuiteDone: this.#onSuiteDone,
+        onSpecStart: this.#onSpecStart,
         onTestRetry: this.#onTestRetry,
         shouldAbort: this.#shouldAbort,
         describeOnly: this.#describeOnly,
-        suiteStarted: this.#suiteStarted,
+        onSuiteStart: this.#onSuiteStart,
+        onRunStart: this.#onRunStart,
       })
 
       const result = this.timeout
@@ -150,14 +154,9 @@ export class ParkinTest {
   }
 
   /**
-   * Sets the test config from the passed in object
-   */
-  setConfig = (config:TParkinTestConfig) => this.#setConfig(config || noOpObj)
-
-  /**
    * Adds passed in framework hooks to the class instance
    */
-  #setConfig = ({
+  setConfig = ({
     timeout,
     testRetry,
     suiteRetry,
@@ -165,24 +164,32 @@ export class ParkinTest {
     onSuiteRetry,
     onAbort,
     autoClean,
-    specDone,
-    suiteDone,
-    specStarted,
-    suiteStarted,
-  }:TParkinTestConfig) => {
-    if (isNum(timeout)) this.timeout = timeout
+    onSpecDone,
+    onSuiteDone,
+    onRunDone,
+    onRunStart,
+    onSpecStart,
+    onSuiteStart,
+  }:TParkinTestConfig=noOpObj) => {
+
     if (onAbort) this.#onAbort = onAbort
+    if (isNum(timeout)) this.timeout = timeout
 
     if (isNum(testRetry)) this.testRetry = testRetry
     if (isNum(suiteRetry)) this.suiteRetry = suiteRetry
+
     if (onTestRetry) this.#onTestRetry = onTestRetry
     if (onSuiteRetry) this.#onSuiteRetry = onSuiteRetry
 
-    if (specDone) this.#specDone = specDone
-    if (suiteDone) this.#suiteDone = suiteDone
-    if (specStarted) this.#specStarted = specStarted
-    if (suiteStarted) this.#suiteStarted = suiteStarted
-    
+    if (onSpecDone) this.#onSpecDone = onSpecDone
+    if (onSpecStart) this.#onSpecStart = onSpecStart
+
+    if (onSuiteDone) this.#onSuiteDone = onSuiteDone
+    if (onSuiteStart) this.#onSuiteStart = onSuiteStart
+
+    if (onRunDone) this.#onRunDone = onRunDone
+    if (onRunStart) this.#onRunStart = onRunStart
+
     if (autoClean === false) this.#autoClean = autoClean
   }
 

--- a/src/types/test.types.ts
+++ b/src/types/test.types.ts
@@ -7,8 +7,8 @@ export enum EResultAction {
   test=`test`,
   skipped=`skipped`,
   start=`start`,
-  end=`end`
-  
+  end=`end`,
+  abort=`abort`
 }
 
 export enum EResultStatus {
@@ -173,10 +173,12 @@ export type TParkinTestConfig = {
   autoClean?:boolean
   description?:string
   onAbort?:TParkinTestAbort
-  specDone?:TParkinTestCB
-  suiteDone?:TParkinTestCB
-  specStarted?:TParkinTestCB
-  suiteStarted?:TParkinTestCB
+  onRunDone?:TParkinTestCB
+  onSpecDone?:TParkinTestCB
+  onRunStart?:TParkinTestCB
+  onSuiteDone?:TParkinTestCB
+  onSpecStart?:TParkinTestCB
+  onSuiteStart?:TParkinTestCB
   onTestRetry?:TPromiseRetryCB<TRunResult>
   onSuiteRetry?:TPromiseRetryCB<TRunResults>
 }
@@ -265,9 +267,9 @@ export type TLoopTests = {
   suiteId:string
   testOnly:boolean
   testRetry?:number
-  specDone:TParkinTestCB
+  onSpecDone:TParkinTestCB
   shouldAbort:() => boolean
-  specStarted:TParkinTestCB
+  onSpecStart:TParkinTestCB
   describe:TDescribeTestObj
   onTestRetry?:TPromiseRetryCB<TRunResult>
 }
@@ -276,13 +278,15 @@ export type TRun = {
   testOnly:boolean
   testRetry?:number
   describeOnly:boolean
-  specDone:TParkinTestCB
-  suiteDone:TParkinTestCB
+  onSpecDone:TParkinTestCB
+  onRunDone:TParkinTestCB
+  onSuiteDone:TParkinTestCB
   onAbort:TParkinTestAbort
   parentIdx?:string|number
   shouldAbort:() => boolean
-  specStarted:TParkinTestCB
-  suiteStarted:TParkinTestCB
+  onSpecStart:TParkinTestCB
+  onRunStart:TParkinTestCB
+  onSuiteStart:TParkinTestCB
   root:TRootTestObj|TDescribeTestObj
   onTestRetry?:TPromiseRetryCB<TRunResult>
 }


### PR DESCRIPTION
* Update run callbacks to all use the on prefix
* Fix bug when ref test metadata object
* Ensure onRunDone and onSuiteDone are always called even when an error is thrown
* Add tests for test run callbacks

BREAKING CHANGE: Normalize test run callbacks names