### PR TITLE
feat: add skip and exit options

### DIFF
--- a/src/bin/__tests__/options.ts
+++ b/src/bin/__tests__/options.ts
@@ -17,7 +17,9 @@ const allowOpts = [
   `config`,
   `disabled`,
   `filter`,
-  `name`
+  `name`,
+  `exitOnFailed`,
+  `skipAfterFailed`
 ]
 
 const allowedTypes = [

--- a/src/bin/options.ts
+++ b/src/bin/options.ts
@@ -64,5 +64,15 @@ export const options = {
     type: `string`,
     example:`--name my-feature`,
     description: `Specify a name of a specific feature to run. All other features will be skipped`,
-  }
+  },
+  exitOnFailed: {
+    type: `bool`,
+    alias: [`eof`],
+    description: `Exit test execution when a test step fails`
+  },
+  skipAfterFailed: {
+    type: `bool`,
+    alias: [`saf`],
+    description: `Skip proceeding tests within the same parent when a test step fails`
+  },
 }

--- a/src/bin/parkin.ts
+++ b/src/bin/parkin.ts
@@ -33,13 +33,19 @@ import { argsParse } from '@keg-hub/args-parse'
     features,
     world,
     defs,
-    { timeout: parsed.timeout },
+    {
+      timeout: parsed.timeout,
+      exitOnFailed: parsed.exitOnFailed,
+      skipAfterFailed: parsed.skipAfterFailed,
+    },
     {
       name: parsed.name,
       timeout: parsed.timeout,
-      tags: pickKeys(parsed,[`disabled`, `filter`]) 
+      tags: pickKeys(parsed,[`disabled`, `filter`])
     },
   )
+  
+    // console.log(require('util').inspect(results, false, null, true))
 
   // TODO: add reporting ???
   // Should figure out a way to reuse Jest || Jasmine reporters

--- a/src/bin/runTests.ts
+++ b/src/bin/runTests.ts
@@ -19,8 +19,10 @@ export const runTests = async (
   runOpts:TParkinRunOpts
 ) => {
 
+  let hasFailed:boolean
   return await features.reduce(async (resolve, feature) => {
     const acc = await resolve
+    if(hasFailed) return acc
 
     const PK = getParkin(world, steps)
     const PTE = getPTE()
@@ -34,6 +36,9 @@ export const runTests = async (
       description: `Parkin > ${feature}`,
       ...testConfig,
     }) as TRunResults
+    
+    if(testConfig?.exitOnFailed)
+      hasFailed = Boolean(responses.find(resp => resp.failed))
 
     return acc.concat(responses)
   }, Promise.resolve([] as TRunResults))

--- a/src/test/__tests__/run.ts
+++ b/src/test/__tests__/run.ts
@@ -441,7 +441,6 @@ describe(`ParkinTest.run`, () => {
 
   })
 
-
   it(`should call the root afterAll hooks when a test throws`, async () => {
 
     const PTE = new ParkinTest()
@@ -469,7 +468,6 @@ describe(`ParkinTest.run`, () => {
     expect(afterAll).toHaveBeenCalled()
 
   })
-
 
   it(`should not call the after hooks when a before hook throws`, async () => {
 
@@ -620,6 +618,98 @@ describe(`ParkinTest.run`, () => {
     const [resp] = await PTE.run()
     expect(resp.failed).toBe(true)
     expect(resp.passed).toBe(false)
+
+  })
+
+
+  it(`should skip proceeding steps if skipAfterFailed is true`, async () => {
+    const test1 = jest.fn()
+    const test2 = jest.fn()
+
+    const PTE = new ParkinTest({
+      skipAfterFailed: true,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1-1`, test1)
+      PTE.test(`test-failed`, () => {
+        throw new Error(`Failed Test`)
+      })
+      PTE.test(`test-skipped`, test2)
+    })
+
+    const [resp] = await PTE.run()
+    expect(resp.failed).toBe(true)
+    expect(resp.passed).toBe(false)
+    expect(test1).toHaveBeenCalled()
+    expect(test2).not.toHaveBeenCalled()
+
+  })
+
+  it(`should not skip steps of a different parent when skipAfterFailed is true`, async () => {
+    const test1 = jest.fn()
+    const test2 = jest.fn()
+    const test3 = jest.fn()
+    const test4 = jest.fn()
+
+    const PTE = new ParkinTest({
+      skipAfterFailed: true,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1-1`, test1)
+      PTE.test(`test-failed`, () => {
+        throw new Error(`Failed Test`)
+      })
+      PTE.test(`test-skipped`, test2)
+    })
+
+    PTE.describe(`describe-2`, () => {
+      PTE.test(`test-2-1`, test3)
+      PTE.test(`test-2-2`, test4)
+    })
+
+    const [resp] = await PTE.run()
+    expect(resp.failed).toBe(true)
+    expect(resp.passed).toBe(false)
+    expect(test1).toHaveBeenCalled()
+    expect(test3).toHaveBeenCalled()
+    expect(test4).toHaveBeenCalled()
+    expect(test2).not.toHaveBeenCalled()
+
+  })
+
+
+  it(`should stop executing test when exitOnFailed is true and a test fails`, async () => {
+    const test1 = jest.fn()
+    const test2 = jest.fn()
+    const test3 = jest.fn()
+    const test4 = jest.fn()
+
+    const PTE = new ParkinTest({
+      exitOnFailed: true,
+    })
+
+    PTE.describe(`describe-1`, () => {
+      PTE.test(`test-1-1`, test1)
+      PTE.test(`test-failed`, () => {
+        throw new Error(`Failed Test`)
+      })
+      PTE.test(`test-skipped`, test2)
+    })
+
+    PTE.describe(`describe-2`, () => {
+      PTE.test(`test-2-1`, test3)
+      PTE.test(`test-2-2`, test4)
+    })
+
+    const [resp] = await PTE.run()
+    expect(resp.failed).toBe(true)
+    expect(resp.passed).toBe(false)
+    expect(test1).toHaveBeenCalled()
+    expect(test2).not.toHaveBeenCalled()
+    expect(test3).not.toHaveBeenCalled()
+    expect(test4).not.toHaveBeenCalled()
 
   })
 

--- a/src/test/__tests__/test.ts
+++ b/src/test/__tests__/test.ts
@@ -691,29 +691,29 @@ describe(`ParkinTest`, () => {
       expect(args.onTestRetry).toBe(onTestRetry2)
     })
 
-  })
+    it(`should retry a suite when suite retry is greater then 0`, async () => {
 
-  it(`should retry a suite when suite retry is greater then 0`, async () => {
+      const onSuiteRetry = jest.fn()
+      const PTE = new ParkinTest({
+        suiteRetry: 1,
+        onSuiteRetry
+      })
 
-    const onSuiteRetry = jest.fn()
-    const PTE = new ParkinTest({
-      suiteRetry: 1,
-      onSuiteRetry
+      failRunMock = true
+
+      try {
+        runMock.mockClear()
+        await PTE.run()
+      }
+      catch(err){
+        expect(err.name).toBe(`RetryError`)
+        expect(runMock).toHaveBeenCalledTimes(2)
+        expect(onSuiteRetry).toHaveBeenCalled()
+      }
+
+      failRunMock = false
+
     })
-
-    failRunMock = true
-
-    try {
-      runMock.mockClear()
-      await PTE.run()
-    }
-    catch(err){
-      expect(err.name).toBe(`RetryError`)
-      expect(runMock).toHaveBeenCalledTimes(2)
-      expect(onSuiteRetry).toHaveBeenCalled()
-    }
-    
-    failRunMock = false
 
   })
 

--- a/src/test/loopDescribes.ts
+++ b/src/test/loopDescribes.ts
@@ -81,6 +81,8 @@ export const loopDescribes = async (args:TRun) => {
     onSuiteStart,
     describeOnly,
     parentIdx = ``,
+    exitOnFailed,
+    skipAfterFailed,
   } = args
 
   let describeFailed = false
@@ -147,9 +149,19 @@ export const loopDescribes = async (args:TRun) => {
             onTestRetry,
             shouldAbort,
             onSpecStart,
+            exitOnFailed,
+            skipAfterFailed,
           })
         })
       : describeResult
+
+
+    if(exitOnFailed && describeResult.failed){
+      describeFailed = true
+      onSuiteDone(describeResult)
+      results.push(describeResult)
+      break
+    }
 
     // Loop over any describe children
     describeResult = describe?.describes?.length
@@ -164,6 +176,14 @@ export const loopDescribes = async (args:TRun) => {
           })
         })
       : describeResult
+
+
+    if(exitOnFailed && describeResult.failed){
+      describeFailed = true
+      onSuiteDone(describeResult)
+      results.push(describeResult)
+      break
+    }
 
     if(shouldAbort()) break
 

--- a/src/test/run.ts
+++ b/src/test/run.ts
@@ -87,6 +87,7 @@ export const run = async (args:TRun):Promise<TRunResults> => {
     describes.push(
       err.result
       || runResult(root, {
+          describes,
           id: Types.root,
           fullName: root.description,
           testPath: `/${Types.root}`,

--- a/src/test/runHelpers.ts
+++ b/src/test/runHelpers.ts
@@ -6,6 +6,8 @@ import type {
 export type TShouldSkipTest = {
   testOnly?:boolean
   test: TTestTestObj
+  hasFailed?:boolean
+  skipAfterFailed?:boolean
 }
 
 export type TBuildTestArgs = {
@@ -21,8 +23,17 @@ export type TShouldSkipDescribe = {
 }
 
 
-export const shouldSkipTest = ({ testOnly, test }:TShouldSkipTest) => {
-  return (testOnly && !test.only) || test.skip
+export const shouldSkipTest = (params:TShouldSkipTest) => {
+  const {
+    test,
+    testOnly,
+    hasFailed,
+    skipAfterFailed
+  } = params
+
+  return test.skip
+    || (testOnly && !test.only)
+    || (hasFailed && skipAfterFailed)
 }
 
 export const buildTestArgs = ({

--- a/src/test/runResult.ts
+++ b/src/test/runResult.ts
@@ -15,11 +15,13 @@ export const runResult = (
   item:TTestObj,
   {
     id,
+    tests,
     action,
     failed,
     passed,
     testPath,
     fullName,
+    describes,
   }:TRunResultTestMeta
 ) => {
 
@@ -36,6 +38,9 @@ export const runResult = (
     description: item.description,
     timestamp: new Date().getTime(),
   }
+
+  if(tests?.length) result.tests = tests
+  if(describes?.length) result.describes = describes
 
   isObj(failed) && result.failedExpectations.push(failed)
   isObj(passed) && result.passedExpectations.push(passed)

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -45,6 +45,8 @@ export class ParkinTest {
   #testOnly = false
   #abortRun = false
   #describeOnly = false
+  #exitOnFailed = false
+  #skipAfterFailed = false
   #root = createRoot()
   xit:TTestSkipFactory
   it:TParkinTestFactory
@@ -86,13 +88,15 @@ export class ParkinTest {
         onSpecDone: this.#onSpecDone,
         testRetry: this.testRetry,
         onRunDone: this.#onRunDone,
+        onRunStart: this.#onRunStart,
         onSuiteDone: this.#onSuiteDone,
         onSpecStart: this.#onSpecStart,
         onTestRetry: this.#onTestRetry,
         shouldAbort: this.#shouldAbort,
         describeOnly: this.#describeOnly,
         onSuiteStart: this.#onSuiteStart,
-        onRunStart: this.#onRunStart,
+        exitOnFailed: this.#exitOnFailed,
+        skipAfterFailed: this.#skipAfterFailed,
       })
 
       const result = this.timeout
@@ -162,6 +166,8 @@ export class ParkinTest {
     suiteRetry,
     onTestRetry,
     onSuiteRetry,
+    exitOnFailed,
+    skipAfterFailed,
     onAbort,
     autoClean,
     onSpecDone,
@@ -191,6 +197,9 @@ export class ParkinTest {
     if (onRunStart) this.#onRunStart = onRunStart
 
     if (autoClean === false) this.#autoClean = autoClean
+
+    if(exitOnFailed) this.#exitOnFailed = exitOnFailed
+    if(skipAfterFailed) this.#skipAfterFailed = skipAfterFailed
   }
 
   /**

--- a/src/types/bin.types.ts
+++ b/src/types/bin.types.ts
@@ -4,6 +4,8 @@ export type TParkinOpts = TLoadOpts & {
   world?: string
   rootDir?:string
   config?:string
+  exitOnFailed?:boolean
+  skipAfterFailed?:boolean
   defs?:string|string[]
   features?:string|string[]
   filter?:string|string[]

--- a/src/types/test.types.ts
+++ b/src/types/test.types.ts
@@ -172,6 +172,8 @@ export type TParkinTestConfig = {
   suiteRetry?:number
   autoClean?:boolean
   description?:string
+  exitOnFailed?:boolean
+  skipAfterFailed?:boolean
   onAbort?:TParkinTestAbort
   onRunDone?:TParkinTestCB
   onSpecDone?:TParkinTestCB
@@ -267,6 +269,8 @@ export type TLoopTests = {
   suiteId:string
   testOnly:boolean
   testRetry?:number
+  exitOnFailed?:boolean
+  skipAfterFailed?:boolean
   onSpecDone:TParkinTestCB
   shouldAbort:() => boolean
   onSpecStart:TParkinTestCB
@@ -278,6 +282,8 @@ export type TRun = {
   testOnly:boolean
   testRetry?:number
   describeOnly:boolean
+  exitOnFailed?:boolean
+  skipAfterFailed?:boolean
   onSpecDone:TParkinTestCB
   onRunDone:TParkinTestCB
   onSuiteDone:TParkinTestCB


### PR DESCRIPTION
## Updates

* Add test option`skipAfterFailed` - Allow skipping future steps when a step fails
* Add test option`exitOnFailed` -  Allow exiting test exec when a step fails
* Fix PromiseRetry error name
  * Only overrides name when retry is set
  * Add result to error when it exists


