### PR TITLE
Wait for callbacks

### DIFF
--- a/src/test/hooks.ts
+++ b/src/test/hooks.ts
@@ -159,12 +159,14 @@ export const callDescribeHooks = async (args:TDescribeHooks) => {
   if(!hooksResults?.length) return results
   
   if (hooksResults?.length) {
-    const describeResults = hooksResults.map(result => {
-      const joined = {...describeResult, ...result, failed: true, passed: false }
-      onSuiteDone(joined)
+    const describeResults = await Promise.all(
+      hooksResults.map(async (result) => {
+        const joined = {...describeResult, ...result, failed: true, passed: false }
+        await onSuiteDone(joined)
 
-      return joined
-    })
+        return joined
+      })
+    )
 
     results.push(...describeResults)
   }

--- a/src/test/loopDescribes.ts
+++ b/src/test/loopDescribes.ts
@@ -54,7 +54,7 @@ const loopChildren = async (args:TLoopChildren) => {
       }
     })
     
-    onSuiteDone(errorResult)
+    await onSuiteDone(errorResult)
     if(!err.result) err.result = errorResult
 
     throw err
@@ -107,7 +107,7 @@ export const loopDescribes = async (args:TRun) => {
 
 
     if (shouldSkipDescribe({ describe, describeOnly, testOnly })) {
-      onSuiteStart({
+      await onSuiteStart({
         ...describeResult,
         skipped: true,
         action: EResultAction.skipped,
@@ -115,7 +115,7 @@ export const loopDescribes = async (args:TRun) => {
       })
       continue
     }
-    else onSuiteStart(describeResult)
+    else await onSuiteStart(describeResult)
 
     const beforeResults = await callDescribeHooks({
       root,
@@ -158,7 +158,7 @@ export const loopDescribes = async (args:TRun) => {
 
     if(exitOnFailed && describeResult.failed){
       describeFailed = true
-      onSuiteDone(describeResult)
+      await onSuiteDone(describeResult)
       results.push(describeResult)
       break
     }
@@ -180,7 +180,7 @@ export const loopDescribes = async (args:TRun) => {
 
     if(exitOnFailed && describeResult.failed){
       describeFailed = true
-      onSuiteDone(describeResult)
+      await onSuiteDone(describeResult)
       results.push(describeResult)
       break
     }
@@ -214,7 +214,7 @@ export const loopDescribes = async (args:TRun) => {
 
     if(shouldAbort()) break
 
-    onSuiteDone(describeResult)
+    await onSuiteDone(describeResult)
     results.push(describeResult)
   }
 

--- a/src/test/loopTests.ts
+++ b/src/test/loopTests.ts
@@ -68,11 +68,11 @@ export const loopTests = async (args:TLoopTests) => {
         status: EResultStatus.skipped,
       }
 
-      onSpecStart(skipped)
+      await onSpecStart(skipped)
       results.push(skipped)
       continue
     }
-    else onSpecStart(testResult)
+    else await onSpecStart(testResult)
 
     if(shouldAbort()) break
 
@@ -131,7 +131,7 @@ export const loopTests = async (args:TLoopTests) => {
 
       if(exitOnFailed){
         results.push(testResult)
-        onSpecDone(testResult)
+        await onSpecDone(testResult)
         break
       }
 
@@ -155,7 +155,7 @@ export const loopTests = async (args:TLoopTests) => {
 
     results.push(testResult)
 
-    onSpecDone({
+    await onSpecDone({
       ...testResult,
       action: EResultAction.end
     })

--- a/src/test/run.ts
+++ b/src/test/run.ts
@@ -36,7 +36,7 @@ export const run = async (args:TRun):Promise<TRunResults> => {
     testPath: `/${Types.root}`,
   })
 
-  onRunStart({
+  await onRunStart({
     ...rootResult,
     action: EResultAction.start,
     description: `Starting test execution`,
@@ -49,9 +49,9 @@ export const run = async (args:TRun):Promise<TRunResults> => {
   })
 
   if(shouldAbort()){
-    onAbort?.()
+    await onAbort?.()
 
-    onRunDone({
+    await onRunDone({
       ...rootResult,
       action: EResultAction.abort,
       description: `Test execution aborted`,
@@ -72,8 +72,8 @@ export const run = async (args:TRun):Promise<TRunResults> => {
     describesFailed = resp.failed
 
     if(shouldAbort()){
-      onAbort?.()
-      onRunDone({
+      await onAbort?.()
+      await onRunDone({
         ...rootResult,
         action: EResultAction.abort,
         description: `Test execution aborted`,
@@ -110,7 +110,7 @@ export const run = async (args:TRun):Promise<TRunResults> => {
     })
     afterAllResult?.length && describes.push(...afterAllResult)
 
-    onRunDone({
+    await onRunDone({
       ...rootResult,
       describes,
       failed: describesFailed,

--- a/src/types/test.types.ts
+++ b/src/types/test.types.ts
@@ -135,8 +135,8 @@ export type TSuite = {
   children: TSpec[]
 }
 
-export type TParkinTestAbort = () => void
-export type TParkinTestCB = (result:TRunResult) => void
+export type TParkinTestAbort = () => Promise<any>|any
+export type TParkinTestCB = (result:TRunResult) => Promise<any>|any
 
 export type TDescribeAction = (() => void) & {
   metaData?:TRunResultActionMeta

--- a/src/types/world.types.ts
+++ b/src/types/world.types.ts
@@ -6,7 +6,7 @@ export type TWorldApp = {
 export type TWorldConfig = {
   url?:string
   app?: TWorldApp
-  merge?: string[]
+  $merge?: string[]
   environment?: string
   data?: Record<string, any>
   $alias: Record<string, any>

--- a/src/utils/__tests__/hasTag.ts
+++ b/src/utils/__tests__/hasTag.ts
@@ -2,26 +2,115 @@ jest.resetModules()
 jest.resetAllMocks()
 jest.clearAllMocks()
 
-const { hasTag } = require('../hasTag')
+const { parseTags, hasTag } = require('../hasTag')
 
 describe(`hasTag`, () => {
 
-  it(`should return false when no tags match`, () => {
-    expect(hasTag(`@tag1 @tag2`, `@tag3 @tag4`)).toBe(false)
+  describe(`hasTag`, () => {
+
+    it(`should return true when both items and options have the same tag`, () => {
+      const oneTag = [`@tag-1`]
+      const twoTag = [`@tag-1`, `@tag-2`]
+
+      expect(hasTag(oneTag, twoTag)).toBe(true)
+      expect(hasTag(twoTag, oneTag)).toBe(true)
+
+      const oneTagStr = oneTag.join(` `)
+      const twoTagStr = twoTag.join(` `)
+
+      expect(hasTag(oneTagStr, twoTagStr)).toBe(true)
+      expect(hasTag(twoTagStr, oneTagStr)).toBe(true)
+
+    })
+
+    it(`should return false when the first argument is missing a tag from the second argument`, () => {
+      const oneTag = [`@tag-1`]
+      const twoTag = [`@tag-2`, `@tag-3`]
+      const oneTagStr = oneTag.join(` `)
+      const twoTagStr = twoTag.join(` `)
+
+      expect(hasTag(oneTag, twoTag)).toBe(false)
+      expect(hasTag(twoTag, oneTag)).toBe(false)
+      expect(hasTag(oneTagStr, twoTagStr)).toBe(false)
+      expect(hasTag(twoTagStr, oneTagStr)).toBe(false)
+
+    })
+
+    it(`should work with arrays of strings and strings`, () => {
+      const string = `@tag-1`
+      const arr = [`@tag-1`, `@tag-2`]
+
+      expect(hasTag(string, arr)).toBe(true)
+      expect(hasTag(arr, string)).toBe(true)
+      expect(hasTag(string, string)).toBe(true)
+      expect(hasTag(arr, arr)).toBe(true)
+    })
+
+    it(`should work even when invalid tags are passed`, () => {
+
+      const oneTag = [`@tag-1`, `something`]
+      const twoTag = [`@tag-1`, `@tag-2`, `item`]
+      const oneTagStr = oneTag.join(` `)
+      const twoTagStr = twoTag.join(` `)
+
+      expect(hasTag(oneTag, twoTag)).toBe(true)
+      expect(hasTag(twoTag, oneTag)).toBe(true)
+
+      expect(hasTag(oneTagStr, twoTagStr)).toBe(true)
+      expect(hasTag(twoTagStr, oneTagStr)).toBe(true)
+
+      expect(hasTag(oneTag, twoTagStr)).toBe(true)
+      expect(hasTag(twoTagStr, oneTag)).toBe(true)
+
+    })
+
   })
 
+  describe(`parseTags`, () => {
 
-  it(`should return true when tags do match`, () => {
-    expect(hasTag(`@tag1 @tag2`, `@tag1 @tag4`)).toBe(true)
+    it(`should properly parse the tag string or array`, () => {
+      const tags = parseTags(`@tag-1 @t3`)
+      const tagsArr = parseTags([`@tag-1`, `@t3`])
+
+      expect(tags.includes(`@t3`)).toBe(true)
+      expect(tags.includes(`@tag-1`)).toBe(true)
+      expect(tagsArr.includes(`@t3`)).toBe(true)
+      expect(tagsArr.includes(`@tag-1`)).toBe(true)
+
+    })
+
+    it(`should properly parse the tag string or array even with invalid tags`, () => {
+      const tags = parseTags(`@tag-1 something tag-2 @t3`)
+      const tagsArr = parseTags([`@tag-1`, `something`, `@t3`, `tag-2`])
+
+      expect(tags.includes(`@t3`)).toBe(true)
+      expect(tags.includes(`@tag-1`)).toBe(true)
+      expect(tagsArr.includes(`@t3`)).toBe(true)
+      expect(tagsArr.includes(`@tag-1`)).toBe(true)
+
+      expect(tags.includes(`tag-2`)).toBe(false)
+      expect(tags.includes(`something`)).toBe(false)
+      expect(tagsArr.includes(`tag-2`)).toBe(false)
+      expect(tagsArr.includes(`something`)).toBe(false)
+
+    })
+
+
+    it(`should returns only the correct tag types`, () => {
+      const tags = parseTags(`@-1-valid @3_ #fail @1-pass,__@__pass`)
+
+      expect(tags.includes(`@3_`)).toBe(true)
+      expect(tags.includes(`@-1-valid`)).toBe(true)
+      expect(tags.includes(`@1-pass`)).toBe(true)
+      expect(tags.includes(`@__pass`)).toBe(true)
+      
+      const tagsArr = parseTags([`@-1-valid`, 143, {}, [`@valid-sub-array`]])
+      expect(tagsArr.includes(`@-1-valid`)).toBe(true)
+      expect(tagsArr.includes(`@valid-sub-array`)).toBe(false)
+
+    })
+
+
   })
-
-
-  it(`should work with both string arrays and strings`, () => {
-    expect(hasTag(`@tag1 @tag2`, [`@tag1`])).toBe(true)
-    expect(hasTag([`@tag1`], `@tag1 @tag2`)).toBe(true)
-    expect(hasTag(`@tag1 @tag2`, [`@tag3`])).toBe(false)
-    expect(hasTag([`@tag3`], `@tag1 @tag2`)).toBe(false)
-  })
-
 
 })

--- a/src/utils/hasTag.ts
+++ b/src/utils/hasTag.ts
@@ -5,11 +5,13 @@ import {eitherArr, emptyArr, isArr, isStr} from "@keg-hub/jsutils"
  * Returns false if input is invalid.
  */
 export const parseTags = (tags?:string|string[]):string[] => {
-  return isStr(tags)
-    ? tags.match(/[@]\w*/g)
+  const parsed = isStr(tags)
+    ? tags.match(/([@](\w|-)*)/g)
     : isArr<string>(tags)
       ? tags
       : emptyArr
+
+  return parsed.filter(tag => isStr(tag) && tag.startsWith(`@`) && tag.length > 2)
 }
 
 /**
@@ -30,5 +32,5 @@ export const hasTag = (
     ? parseTags(compareTags)
     : eitherArr<string[]>(compareTags, [])
 
-  return Boolean(cTags.find((cTag) => itemTags.includes(cTag)))
+  return Boolean(cTags.find((cTag) => iTags.includes(cTag)))
 }


### PR DESCRIPTION
## Updates

* The test runner currently does not wait for the callbacks to finish
  * This causes issues when they are async
  * It creates a race condition when the tests finish before the callback does
* This PR adds await to all the callbacks, so that the runner will wait until the callbacks complete before moving on to the next test
* It also includes tests and fixes for tags
