### PR TITLE
chore: build plugins with package

### DIFF
--- a/configs/build.config.ts
+++ b/configs/build.config.ts
@@ -15,6 +15,7 @@ const globalParkin = path.join(rootDir, `src/global.js`)
 const testEntry = path.join(rootDir, `src/test/index.js`)
 const globalTest = path.join(rootDir, `src/test/global.js`)
 const reportersEntry = path.join(rootDir, `src/bin/reporters/index.js`)
+const pluginsEntry = path.join(rootDir, `plugins/index.js`)
 
 const minify = false
 
@@ -28,40 +29,38 @@ const shared = {
     globalTest,
     parkinEntry,
     globalParkin,
-    reportersEntry
+    reportersEntry,
+    pluginsEntry,
   ],
 }
 
 const cjsBuild = async () => {
   // Build the files with esbuild
-  await esbuild.build({
-    ...shared,
-    outdir: cjsOut,
-    platform: "node",
-    target: ["node16"],
-    plugins: [nodeModulesPolyfillPlugin()]
-  })
-  .catch(() => process.exit(1))
+  await esbuild
+    .build({
+      ...shared,
+      outdir: cjsOut,
+      platform: 'node',
+      target: ['node16'],
+      plugins: [nodeModulesPolyfillPlugin()],
+    })
+    .catch(() => process.exit(1))
 }
 
 const esmBuild = async () => {
   // Build the files with esbuild
-  await esbuild.build({
-    ...shared,
-    format: "esm",
-    outdir: esmOut,
-    splitting: true,
-    target: ["esnext"],
-    define: { global: "window" },
-    plugins: [
-      nodeModulesPolyfillPlugin(),
-      typecheckPlugin(),
-      dtsPlugin(),
-    ]
-  })
-  .catch(() => process.exit(1))
+  await esbuild
+    .build({
+      ...shared,
+      format: 'esm',
+      outdir: esmOut,
+      splitting: true,
+      target: ['esnext'],
+      define: { global: 'window' },
+      plugins: [nodeModulesPolyfillPlugin(), typecheckPlugin(), dtsPlugin()],
+    })
+    .catch(() => process.exit(1))
 }
-
 
 ;(async () => {
   await cjsBuild()

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,0 +1,1 @@
+export * from "./maestro";

--- a/plugins/maestro/constants.ts
+++ b/plugins/maestro/constants.ts
@@ -41,4 +41,5 @@ export enum EMaestroCmds {
   doubleTapOn=`doubleTapOn`,
   travel=`travel`,
   waitForAnimationToEnd=`waitForAnimationToEnd`,
+  longPressOn='longPressOn'
 }

--- a/plugins/maestro/steps/when.ts
+++ b/plugins/maestro/steps/when.ts
@@ -1,16 +1,29 @@
 import type { Maestro } from "../maestro"
 import { EMaestroCmds } from "../constants"
 
-export const buildWhenSteps = (maestro:Maestro) => {
+export const buildWhenSteps = (maestro: Maestro) => {
 
   maestro.parkin.When(`I tap the {string} {string}`, (
-    selector:string,
-    type:string
+    selector: string,
+    type: string,
   ) => {
     maestro.flow.addStep({
       cmd: EMaestroCmds.tapOn,
       children: { [type]: selector }
     })
   })
+  
+  maestro.parkin.When(`I long press the {string} {string}`, (selector: string, type: string) => {
+    maestro.flow.addStep({
+      cmd: EMaestroCmds.longPressOn,
+      children: {[type]: selector}
+    })
+  })
 
+  maestro.parkin.When(`I input {string}`, (text: string) => {
+    maestro.flow.addStep({
+      cmd: EMaestroCmds.inputText,
+      args: [text]
+    })
+  })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "plugins/**/*"],
   "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
Not sure if this is how you planned on packaging plugins, but this at the very least has allowed me to link the package locally and import the Maestro plugin via:

`import { Maestro } from "@ltipton/parkin/build/esm/plugins";`